### PR TITLE
Add check to see if a a project has a completed at date

### DIFF
--- a/resources/views/pages/project.blade.php
+++ b/resources/views/pages/project.blade.php
@@ -66,7 +66,14 @@
                             <div class="row">
                                 <div class="col-md-4">
                                     <ul>
-                                        <li><span>Date :</span> {{ $project->completed_at->toDateString() }} </li>
+                                        <li>
+                                            <span>CompletionDate :</span> 
+                                            @isset($project->completed_at)
+                                                {{ $project->completed_at->toDateString() }} 
+                                            @else
+                                                {{ 'Current Project' }}
+                                            @endisset
+                                        </li>
                                         @isset($project->client)
                                             <li><span>Client :</span>  {{ $project->client->name }} </li>
                                         @endisset


### PR DESCRIPTION
With this pull request, we are fixing an error that is shown when a project doesn't have a completed_at fieldset. If it is set then we are displaying that it's a present project.