### PR TITLE
Change link on project page to portfolio

### DIFF
--- a/resources/views/pages/project.blade.php
+++ b/resources/views/pages/project.blade.php
@@ -10,7 +10,7 @@
             </div>
             <span>Scroll Down</span>
         </div>
-        <a href="{{ route('home') }}" class="single-page-fixed-row-link"><i class="fal fa-arrow-left"></i> <span>Back to home</span></a>
+        <a href="{{ route('portfolio') }}" class="single-page-fixed-row-link"><i class="fal fa-arrow-left"></i> <span>Back to portfolio</span></a>
     </div>
     <!-- section  -->
     <section class="no-padding dark-bg no-hidden">


### PR DESCRIPTION
With this pull request, we are changing the link on the project page to redirect back to the portfolio page as I feel its better to send them there than it is to send them to the home page.